### PR TITLE
[HOTFIX] Refresh with cached content in /inbound/check

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - hotifx-autodeploy  # TODO: remove this line
 
 jobs:
   UpdateDevContainer:

--- a/core_model/app/main/config.py
+++ b/core_model/app/main/config.py
@@ -4,9 +4,8 @@
 
 from flask import current_app
 
-from .. import get_text_preprocessor
+from .. import refresh_language_context
 from ..prometheus_metrics import metrics
-from ..src.utils import load_language_context
 from . import main
 from .auth import auth
 
@@ -18,21 +17,6 @@ def edit_language_context():
     """
     Update faqt model language contexts with the current configuration in the database
     """
-    language_context = load_language_context(current_app)
+    version = refresh_language_context(current_app)
 
-    current_app.faqt_model.set_glossary(
-        language_context.custom_wvs if language_context else {}
-    )
-
-    current_app.faqt_model.set_tokenizer(
-        get_text_preprocessor(
-            language_context.pairwise_triplewise_entities if language_context else {}
-        )
-    )
-    current_app.faqt_model.set_tags_guiding_typos(
-        language_context.tag_guiding_typos if language_context else []
-    )
-    if language_context is None:
-        return "Empty"
-    else:
-        return language_context.version_id
+    return version

--- a/core_model/app/main/inbound.py
+++ b/core_model/app/main/inbound.py
@@ -12,6 +12,7 @@ from flask import current_app, request, url_for
 from flask_restx import Resource
 from sqlalchemy.orm.attributes import flag_modified
 
+from .. import refresh_faqs_cached, refresh_language_context_cached
 from ..data_models import Inbound
 from ..database_sqlalchemy import db
 from ..prometheus_metrics import metrics
@@ -82,6 +83,9 @@ class InboundCheck(Resource):
         """
         See class docstring for details.
         """
+        n_faqs = refresh_faqs_cached(current_app)
+        language_context_version = refresh_language_context_cached(current_app)
+
         incoming = request.json
         if "return_scoring" in incoming:
             return_scoring = incoming["return_scoring"]

--- a/core_model/app/src/utils.py
+++ b/core_model/app/src/utils.py
@@ -12,8 +12,6 @@ import yaml
 from gensim.models import KeyedVectors
 from gensim.models.fasttext import load_facebook_vectors
 
-from ..data_models import LanguageContextModel
-
 
 def load_fasttext(folder, filename):
     """Load fasttext word embedding"""
@@ -180,14 +178,6 @@ class DefaultEnvDict(UserDict):
         if value is None:
             raise KeyError(f"{key} not found in dict or environment variables")
         return os.getenv(key)
-
-
-def load_language_context(app):
-    """Get language contextualization config from database"""
-    with app.app_context():
-        language_context = LanguageContextModel.query.filter_by(active=True).first()
-
-    return language_context
 
 
 def deep_update(dict_to_update, update_values):


### PR DESCRIPTION
Reviewer: @lickem22 
Estimate: 2 hours


----------

# [HOTFIX] Refresh with cached content in /inbound/check

## Ticket

No ticket -- this is a hotfix.

## Description, Motivation and Context

Problem: we would update an FAQ or UD rule, and the same request would give us different responses — ones reflecting the content update vs. ones that didn’t.

Cause: we use gunicorn workers to run the app, but when we hit the endpoints for updating FAQs, UD rules, or language contextualization configs, this update is made only in one of the workers. So depending on which worker handles the next `/inbound/check` request, you will get inconsistent results.

Solution: we will call cached versions of content refresh functions within `/inbound/check`. 

## How Has This Been Tested?

Locally and on dev instance by starting the container, updating FAQ or UD rule or language context, and making the same requests multiple times manually and checking that the results are consistent.

## To-do before merge

- [ ] End-to-end testing
- [ ] Load testing

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have written [good commit messages][1]
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
