### PR TITLE
Cached refresh take2

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - hotifx-autodeploy  # TODO: remove this line
+      - cached_refresh_take2  # TODO: remove this line
 
 jobs:
   UpdateDevContainer:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - cached_refresh_take2  # TODO: remove this line
 
 jobs:
   UpdateDevContainer:

--- a/core_model/app/__init__.py
+++ b/core_model/app/__init__.py
@@ -13,7 +13,7 @@ from faqt.model.faq_matching.contextualization import (
 from flask import Flask
 from hunspell import Hunspell
 
-from .data_models import FAQModel
+from .data_models import FAQModel, LanguageContextModel
 from .database_sqlalchemy import db, migrate
 from .prometheus_metrics import metrics
 from .src.faq_weights import add_faq_weight_share
@@ -22,7 +22,6 @@ from .src.utils import (
     deep_update,
     get_postgres_uri,
     load_data_sources,
-    load_language_context,
     load_parameters,
     load_word_embeddings_bin,
 )
@@ -177,6 +176,7 @@ def init_faqt_model(app):
     )
 
     app.cached_faq_func = cached_faqs_wrapper(app)
+    app.cached_language_context_func = cached_language_context_wrapper(app)
 
 
 def get_text_preprocessor(pairwise_entities):
@@ -246,3 +246,58 @@ def refresh_faqs_cached(app):
     Refresh FAQs every hour, and cache the result
     """
     return app.cached_faq_func(ttl_hash=get_ttl_hash())
+
+
+def load_language_context(app):
+    """
+    Load language contextualization config from database
+    """
+    with app.app_context():
+        language_context = LanguageContextModel.query.filter_by(active=True).first()
+
+    return language_context
+
+
+def refresh_language_context(app):
+    """
+    Update faqt model language contexts with the current configuration in the database
+    """
+    language_context = load_language_context(app)
+
+    app.faqt_model.set_glossary(language_context.custom_wvs if language_context else {})
+
+    app.faqt_model.set_tokenizer(
+        get_text_preprocessor(
+            language_context.pairwise_triplewise_entities if language_context else {}
+        )
+    )
+
+    app.faqt_model.set_tags_guiding_typos(
+        language_context.tag_guiding_typos if language_context else []
+    )
+
+    if language_context is None:
+        return "Empty"
+    else:
+        return language_context.version_id
+
+
+def cached_language_context_wrapper(app):
+    """Wrapper to cached language context func"""
+
+    @lru_cache(maxsize=1)
+    def cached_language_context(ttl_hash):
+        """
+        Caches `refresh_language_context` results
+        """
+        version_id = refresh_language_context(app)
+        return version_id
+
+    return cached_language_context
+
+
+def refresh_language_context_cached(app):
+    """
+    Refresh Language context every hour, and cache the result
+    """
+    return app.cached_language_context_func(ttl_hash=get_ttl_hash())

--- a/core_model/app/main/config.py
+++ b/core_model/app/main/config.py
@@ -4,9 +4,8 @@
 
 from flask import current_app
 
-from .. import get_text_preprocessor
+from .. import get_text_preprocessor, refresh_language_context
 from ..prometheus_metrics import metrics
-from ..src.utils import load_language_context
 from . import main
 from .auth import auth
 
@@ -18,21 +17,5 @@ def edit_language_context():
     """
     Update faqt model language contexts with the current configuration in the database
     """
-    language_context = load_language_context(current_app)
-
-    current_app.faqt_model.set_glossary(
-        language_context.custom_wvs if language_context else {}
-    )
-
-    current_app.faqt_model.set_tokenizer(
-        get_text_preprocessor(
-            language_context.pairwise_triplewise_entities if language_context else {}
-        )
-    )
-    current_app.faqt_model.set_tags_guiding_typos(
-        language_context.tag_guiding_typos if language_context else []
-    )
-    if language_context is None:
-        return "Empty"
-    else:
-        return language_context.version_id
+    version = refresh_language_context(current_app)
+    return version

--- a/core_model/app/main/inbound.py
+++ b/core_model/app/main/inbound.py
@@ -12,7 +12,6 @@ from flask import current_app, request, url_for
 from flask_restx import Resource
 from sqlalchemy.orm.attributes import flag_modified
 
-from .. import refresh_faqs_cached
 from ..data_models import Inbound
 from ..database_sqlalchemy import db
 from ..prometheus_metrics import metrics
@@ -83,7 +82,8 @@ class InboundCheck(Resource):
         """
         See class docstring for details.
         """
-        refresh_faqs_cached(current_app)
+        n_faqs = refresh_faqs_cached(current_app)
+        language_context_version = refresh_language_context_cached(current_app)
         incoming = request.json
         if "return_scoring" in incoming:
             return_scoring = incoming["return_scoring"]

--- a/core_model/app/main/inbound.py
+++ b/core_model/app/main/inbound.py
@@ -12,6 +12,7 @@ from flask import current_app, request, url_for
 from flask_restx import Resource
 from sqlalchemy.orm.attributes import flag_modified
 
+from .. import refresh_faqs_cached, refresh_language_context_cached
 from ..data_models import Inbound
 from ..database_sqlalchemy import db
 from ..prometheus_metrics import metrics

--- a/core_model/app/main/inbound.py
+++ b/core_model/app/main/inbound.py
@@ -12,6 +12,7 @@ from flask import current_app, request, url_for
 from flask_restx import Resource
 from sqlalchemy.orm.attributes import flag_modified
 
+from .. import refresh_faqs_cached
 from ..data_models import Inbound
 from ..database_sqlalchemy import db
 from ..prometheus_metrics import metrics
@@ -82,6 +83,7 @@ class InboundCheck(Resource):
         """
         See class docstring for details.
         """
+        refresh_faqs_cached(current_app)
         incoming = request.json
         if "return_scoring" in incoming:
             return_scoring = incoming["return_scoring"]


### PR DESCRIPTION
Reviewer: @suzinyou 
Estimate: 1 hours


----------

# [HOTFIX] Refresh with cached content in /inbound/check

## Ticket

No ticket -- this is a hotfix.

## Description, Motivation and Context

Problem: we would update an FAQ or UD rule, and the same request would give us different responses — ones reflecting the content update vs. ones that didn’t.

Cause: we use gunicorn workers to run the app, but when we hit the endpoints for updating FAQs, UD rules, or language contextualization configs, this update is made only in one of the workers. So depending on which worker handles the next `/inbound/check` request, you will get inconsistent results.

Solution: we will call cached versions of content refresh functions within `/inbound/check`. 

## How Has This Been Tested?

Locally and on dev instance by starting the container, updating FAQ or UD rule or language context, and making the same requests multiple times manually and checking that the results are consistent.

## To-do before merge

- [ ] End-to-end testing
- [ ] Load testing

## Checklist:

This checklist is a useful reminder of small things that can easily be forgotten.
Put an `x` in all the items that apply and remove any items that are not relevant to this PR.

- [ ] My code follows the style guidelines of this project
- [ ] I have reviewed my own code to ensure good quality
- [ ] I have tested the functionality of my code to ensure it works as intended
- [ ] I have resolved merge conflicts
- [ ] I have updated the automated tests (if applicable)
- [ ] I have written [good commit messages][1]
- [ ] I have updated the README file (if applicable)
- [ ] I have updated affected documentation (if applicable)

[1]: http://chris.beams.io/posts/git-commit/
